### PR TITLE
Mathjax 3 (no Greek)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,22 +6,6 @@ layout: default
 {% include JB/setup %}
 {% include themes/hooligan/post.html %}
 
-
-<script type="text/javascript">
-  document.addEventListener('DOMContentLoaded', function(){
-    function stripcdata(x) {
-      if (x.startsWith('% <![CDATA[') && x.endsWith('%]]>'))
-        return x.substring(11,x.length-4);
-      return x;
-    }
-    document.querySelectorAll("script[type='math/tex']").forEach(function(el){
-      el.outerHTML = "\\(" + stripcdata(el.textContent) + "\\)";
-    });
-    document.querySelectorAll("script[type='math/tex; mode=display']").forEach(function(el){
-      el.outerHTML = "\\[" + stripcdata(el.textContent) + "\\]";
-    });
-    var script = document.createElement('script');
-    script.src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
-    document.head.appendChild(script);
-  }, false);
-  </script>
+<script type="text/javascript" async
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML">
+</script>


### PR DESCRIPTION
Δεν υποστηρίζονται ακόμα unicode, αφού το μόνο font που έχουν στην έκδοση 3 είναι το Mathjax Tex